### PR TITLE
Working

### DIFF
--- a/src/main/java/gov/usgs/locator/Event.java
+++ b/src/main/java/gov/usgs/locator/Event.java
@@ -574,13 +574,15 @@ public class Event {
               pickIn.Site.Latitude,
               pickIn.Site.Longitude,
               (pickIn.Site.Elevation / 1000));
+      // when a pick is formed, the associator phase is used as the current phase, not the picked phase which would 
+      // always be set to P
       gov.usgs.locator.Pick pick =
           new gov.usgs.locator.Pick(
               station,
               pickIn.Site.Channel,
               LocUtil.toHydraTime(pickIn.Time.getTime()),
               pickIn.Use,
-              phCode);
+              obsCode);
       pick.setPhaseIdInfo(
           sourceStr,
           pickIn.ID,

--- a/src/main/java/gov/usgs/locator/Event.java
+++ b/src/main/java/gov/usgs/locator/Event.java
@@ -574,7 +574,8 @@ public class Event {
               pickIn.Site.Latitude,
               pickIn.Site.Longitude,
               (pickIn.Site.Elevation / 1000));
-      // when a pick is formed, the associator phase is used as the current phase, not the picked phase which would 
+      // when a pick is formed, the associator phase is used as the current phase, not the picked
+      // phase which would
       // always be set to P
       gov.usgs.locator.Pick pick =
           new gov.usgs.locator.Pick(

--- a/src/main/java/gov/usgs/locator/InitialPhaseID.java
+++ b/src/main/java/gov/usgs/locator/InitialPhaseID.java
@@ -137,13 +137,15 @@ public class InitialPhaseID {
         // not work correctly.  Note that only some of the first arrivals
         // that are being used are considered and that the tentative ID is
         // not remembered.
+        
         if (group.getDistance() <= 100d) {
           Pick pick = group.getPicks().get(0);
           boolean found;
 
           if (pick.getIsUsed()) {
             String phCode = pick.getCurrentPhaseCode();
-
+            
+            /**
             if (pick.getIsAutomatic()
                 && (phCode.length() == 0
                     || (!"PK".equals(phCode.substring(0, 1))
@@ -167,31 +169,33 @@ public class InitialPhaseID {
                     String.format("InitialPhaseID: %s -> %s auto", phCode, travelTime.getPhCode()));
               }
             } else {
-              found = false;
+            **/	
+          
+          found = false;
+          
+          for (int i = 0; i < ttList.getNumPhases(); i++) {
+            travelTime = ttList.getPhase(i);
 
-              for (int i = 0; i < ttList.getNumPhases(); i++) {
-                travelTime = ttList.getPhase(i);
-
-                if (phCode.equals(travelTime.getPhCode())) {
-                  // Note that this is slightly different from the Fortran
-                  // version where the weight is always from the first arrival.
-                  pick.setResidual(pick.getTravelTime() - travelTime.getTT());
-                  pick.setWeight(1d / travelTime.getSpread());
-                  found = true;
-                  break;
-                }
-              }
-
-              if (!found) {
-                travelTime = ttList.getPhase(0);
-                pick.setResidual(pick.getTravelTime() - travelTime.getTT());
-                pick.setWeight(1d / travelTime.getSpread());
-
-                LOGGER.finer(
-                    String.format(
-                        "InitialPhaseID: " + "%s -> %s human", phCode, travelTime.getPhCode()));
-              }
+            if (phCode.equals(travelTime.getPhCode())) {
+              // Note that this is slightly different from the Fortran
+              // version where the weight is always from the first arrival.
+              pick.setResidual(pick.getTravelTime() - travelTime.getTT());
+              pick.setWeight(1d / travelTime.getSpread());
+              found = true;
+              break;
             }
+          }
+
+          if (!found) {
+            travelTime = ttList.getPhase(0);
+            pick.setResidual(pick.getTravelTime() - travelTime.getTT());
+            pick.setWeight(1d / travelTime.getSpread());
+
+            LOGGER.finer(
+                String.format(
+                    "InitialPhaseID: " + "%s -> %s human", phCode, travelTime.getPhCode()));
+          }
+            //}
 
             weightedResiduals.add(
                 new WeightedResidual(

--- a/src/main/java/gov/usgs/locator/InitialPhaseID.java
+++ b/src/main/java/gov/usgs/locator/InitialPhaseID.java
@@ -137,65 +137,54 @@ public class InitialPhaseID {
         // not work correctly.  Note that only some of the first arrivals
         // that are being used are considered and that the tentative ID is
         // not remembered.
-        
+
         if (group.getDistance() <= 100d) {
           Pick pick = group.getPicks().get(0);
           boolean found;
 
           if (pick.getIsUsed()) {
             String phCode = pick.getCurrentPhaseCode();
-            
+
             /**
-            if (pick.getIsAutomatic()
-                && (phCode.length() == 0
-                    || (!"PK".equals(phCode.substring(0, 1))
-                        && !"P'".equals(phCode.substring(0, 1))
-                        && !"Sc".equals(phCode.substring(0, 1))
-                        && !"Sg".equals(phCode)
-                        && !"Sb".equals(phCode)
-                        && !"Sn".equals(phCode)
-                        && !"Lg".equals(phCode)))) {
-              travelTime = ttList.getPhase(0);
+             * if (pick.getIsAutomatic() && (phCode.length() == 0 ||
+             * (!"PK".equals(phCode.substring(0, 1)) && !"P'".equals(phCode.substring(0, 1)) &&
+             * !"Sc".equals(phCode.substring(0, 1)) && !"Sg".equals(phCode) && !"Sb".equals(phCode)
+             * && !"Sn".equals(phCode) && !"Lg".equals(phCode)))) { travelTime = ttList.getPhase(0);
+             *
+             * <p>if (!phCode.equals(travelTime.getPhCode())) { badPs++; }
+             *
+             * <p>pick.setResidual(pick.getTravelTime() - travelTime.getTT()); pick.setWeight(1d /
+             * travelTime.getSpread());
+             *
+             * <p>if (!phCode.equals(travelTime.getPhCode())) { LOGGER.finer(
+             * String.format("InitialPhaseID: %s -> %s auto", phCode, travelTime.getPhCode())); } }
+             * else {
+             */
+            found = false;
 
-              if (!phCode.equals(travelTime.getPhCode())) {
-                badPs++;
+            for (int i = 0; i < ttList.getNumPhases(); i++) {
+              travelTime = ttList.getPhase(i);
+
+              if (phCode.equals(travelTime.getPhCode())) {
+                // Note that this is slightly different from the Fortran
+                // version where the weight is always from the first arrival.
+                pick.setResidual(pick.getTravelTime() - travelTime.getTT());
+                pick.setWeight(1d / travelTime.getSpread());
+                found = true;
+                break;
               }
-
-              pick.setResidual(pick.getTravelTime() - travelTime.getTT());
-              pick.setWeight(1d / travelTime.getSpread());
-
-              if (!phCode.equals(travelTime.getPhCode())) {
-                LOGGER.finer(
-                    String.format("InitialPhaseID: %s -> %s auto", phCode, travelTime.getPhCode()));
-              }
-            } else {
-            **/	
-          
-          found = false;
-          
-          for (int i = 0; i < ttList.getNumPhases(); i++) {
-            travelTime = ttList.getPhase(i);
-
-            if (phCode.equals(travelTime.getPhCode())) {
-              // Note that this is slightly different from the Fortran
-              // version where the weight is always from the first arrival.
-              pick.setResidual(pick.getTravelTime() - travelTime.getTT());
-              pick.setWeight(1d / travelTime.getSpread());
-              found = true;
-              break;
             }
-          }
 
-          if (!found) {
-            travelTime = ttList.getPhase(0);
-            pick.setResidual(pick.getTravelTime() - travelTime.getTT());
-            pick.setWeight(1d / travelTime.getSpread());
+            if (!found) {
+              travelTime = ttList.getPhase(0);
+              pick.setResidual(pick.getTravelTime() - travelTime.getTT());
+              pick.setWeight(1d / travelTime.getSpread());
 
-            LOGGER.finer(
-                String.format(
-                    "InitialPhaseID: " + "%s -> %s human", phCode, travelTime.getPhCode()));
-          }
-            //}
+              LOGGER.finer(
+                  String.format(
+                      "InitialPhaseID: " + "%s -> %s human", phCode, travelTime.getPhCode()));
+            }
+            // }
 
             weightedResiduals.add(
                 new WeightedResidual(

--- a/src/main/java/gov/usgs/locator/LocInput.java
+++ b/src/main/java/gov/usgs/locator/LocInput.java
@@ -257,7 +257,7 @@ public class LocInput extends LocationRequest {
       if (!scan.hasNextDouble()) {
         curPh = scan.next();
       }
-      newPick.PickedPhase = curPh;
+      newPick.AssociatedPhase = curPh;
 
       newPick.Time = new Date(LocUtil.toJavaTime(scan.nextDouble()));
       newPick.Use = LocUtil.getBoolean(scan.next().charAt(0));
@@ -299,8 +299,8 @@ public class LocInput extends LocationRequest {
         }
       }
       newPick.Affinity = aff;
-      newPick.AssociatedPhase = obsPh;
-
+      newPick.PickedPhase = obsPh;
+      
       if (newPick.isValid()) {
         // Add the pick to the list
         pickList.add(newPick);

--- a/src/main/java/gov/usgs/locator/LocInput.java
+++ b/src/main/java/gov/usgs/locator/LocInput.java
@@ -300,7 +300,7 @@ public class LocInput extends LocationRequest {
       }
       newPick.Affinity = aff;
       newPick.PickedPhase = obsPh;
-      
+
       if (newPick.isValid()) {
         // Add the pick to the list
         pickList.add(newPick);

--- a/src/main/java/gov/usgs/locator/PickGroup.java
+++ b/src/main/java/gov/usgs/locator/PickGroup.java
@@ -57,7 +57,7 @@ public class PickGroup {
   }
 
   /**
-   * Function to get he picks observed in this group (station).
+   * Function to get the picks observed in this group (station).
    *
    * @return An ArrayList of Pick objects containing the picks observed in this group (station).
    */


### PR DESCRIPTION
Here are a few very small tweaks that you may want to disregard. I'd like to test out though. 

1) I think there was a bug where the code was reversing the 'picker phase' and 'assoc phase' from the input file. I checked with Dave K to see what the correct order should be, but please double-check this. 

2) I made it so the initial phase of a pick is set from the assoc phase, instead of the picker phase. I think this makes sense because the picker is always set to P, but the associator is supplying a reasonable location and has already tried to reconcile phase types. 

3) This is where I will probably get yelled at, but commented out the portion of the code that in the case of automatic picks, and sets their phase to be first arriving (P), and strips any secondary picks. This relabeling causes smaller events which consist of many S picks to go off the deep end in some cases. I THINK that this is legacy code where automatics were routinely terrible, but I THINK we are at a point where it's better to put some trust in the associator assigned phase labels than to completely disregard them. That said, commenting out this block may be a bit draconian so if there may be a more thought out solution. I am just saving pushing these changes for consideration. 

