### PR TITLE
Hydra Integration changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The results of this example (and associated log file) are expected to match the
 results found in the legacy output file `LocOutput1000010563_23.txt` file
 provided in the examples directory.
 
-To run the neic-locator as a web service, run the command `java -jar build/libs/./gra --mode=service`
+To run the neic-locator as a web service, run the command `java -jar build/libs/neic-locator-0.2.0-all.jar --mode=service`
 
 To run the neic-locator from the docker container, run the command `docker run --rm -it -p 8080:8080 usgs/neic-locator:latest`
 

--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ build/models/ as part of the gradle build.
 An example legacy input file `LocOutput1000010563_23.txt` is provided in the
 examples directory.
 
-To run this example, run the command  `java -jar build/libs/neic-locator-0.1.0-all.jar --modelPath=./build/models/ --filePath=./examples/raylocinput1000010563_23.txt  --logLevel=debug`
+To run this example, run the command  `java -jar build/libs/neic-locator-0.2.0-all.jar --modelPath=./build/models/ --inputFile=./examples/raylocinput1000010563_23.txt  --logLevel=debug`
 
 The results of this example (and associated log file) are expected to match the
 results found in the legacy output file `LocOutput1000010563_23.txt` file
 provided in the examples directory.
 
-To run the neic-locator as a web service, run the command `java -jar build/libs/neic-locator-0.1.0-all.jar --mode=service`
+To run the neic-locator as a web service, run the command `java -jar build/libs/./gra --mode=service`
 
 To run the neic-locator from the docker container, run the command `docker run --rm -it -p 8080:8080 usgs/neic-locator:latest`
 

--- a/src/main/java/gov/usgs/locator/LocMain.java
+++ b/src/main/java/gov/usgs/locator/LocMain.java
@@ -96,18 +96,18 @@ public class LocMain {
   public static void main(String[] args) {
     if (args == null || args.length == 0) {
       System.out.println(
-          "Usage:\nneic-locator --modelPath=[model path] --inputType=[json, detection, or hydra] "
-              + "\n\t--logFile=[optional log file] --logPath=[log file path] --logLevel=[logging level] "
-              + "\n\t--inputFile=[input file path] [--outputType=[optional json or hydra]]"
-              + "\n\t[--locationConfig='optional config file path']"
+          "Version: "
+              + VERSION
+              + "\nUsage:\nneic-locator --modelPath=[model path] --inputType=[json, detection, or hydra] "
+              + "\n\t[--logFile=[optional log file]] --logPath=[log file path] --logLevel=[logging level] "
+              + "\n\t--inputFile=[input file path] [--outputFile=[optional output file path]] "
+              + "\n\t[--outputType=[optional json or hydra]] [--locationConfig='optional config file path']"
               + "\nneic-locator --mode=batch --modelPath=[model path] "
-              + "\n\t--inputType=[json, detection, or hydra] --logFile=[optional log file] "
+              + "\n\t--inputType=[json, detection, or hydra] [--logFile=[optional log file]] "
               + "\n\t--logPath=[log file path] --logLevel=[logging level] "
-              + "\n\t--inputDir=[input directory path] "
-              + "\n\t--outputDir=[output directory path] "
-              + "[--archiveDir=[optional archive path]] "
-              + "\n\t[--outputType=[optional json or hydra]] "
-              + "[--locationConfig='optional config file path']"
+              + "\n\t--inputDir=[input directory path] --outputDir=[output directory path] "
+              + "\n\t[--archiveDir=[optional archive path]] [--outputType=[optional json or hydra]] "
+              + "\n\t[--locationConfig='optional config file path']"
               + "\n\t--csvFile=[optional csv file path]"
               + "\nneic-locator --mode=service");
       System.exit(1);

--- a/src/main/java/gov/usgs/locator/LocMain.java
+++ b/src/main/java/gov/usgs/locator/LocMain.java
@@ -257,7 +257,7 @@ public class LocMain {
               filePath,
               inputType,
               outputType,
-              "./",
+              outputPath,
               outputExtension,
               csvFile,
               locationConfig);

--- a/src/main/java/gov/usgs/locator/Pick.java
+++ b/src/main/java/gov/usgs/locator/Pick.java
@@ -463,7 +463,7 @@ public class Pick implements Comparable<Pick> {
    *     identification and location)
    * @param originalAssocPhaseCode A String containing the original associator external pick phase
    *     identification
-   * @param originaPickedPhaseCode A String containing the original picker external pick phase
+   * @param originalPickedPhaseCode A String containing the original picker external pick phase
    *     identification
    * @param originalAuthorType An AuthorType object containing the type (e.g., human or auto) of the
    *     original phase identification


### PR DESCRIPTION
This PR makes a number of small changes to LocMain to better support the integration of the java locator into the Hydra system. Primarily these changes revolved around adding the capability to externally specify (via the command line) the location of the output and log files. By default the java locator should work the same as before, with the exception of the `inputPath` command line argument being renamed to `inputFile`.

A javadoc error was also fixed in this PR.