### PR TITLE
Bug Fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
 
 sourceCompatibility = "1.10"
 targetCompatibility = "1.10"
-version = "0.3.1"
+version = "0.3.2"
 
 repositories {
     mavenCentral()

--- a/src/main/java/gov/usgs/locator/Event.java
+++ b/src/main/java/gov/usgs/locator/Event.java
@@ -1117,7 +1117,15 @@ public class Event {
         break;
 
       case INSUFFICIENT_DATA:
-        locatorExitCode = LocStatus.NOT_ENOUGH_DATA;
+        // insufficent data can either mean not enough
+        // input data was provided OR there was not
+        // enough data with a non-zero weight after
+        // phase (re)identification
+        if (numPhasesAssociated < 3) {
+          locatorExitCode = LocStatus.NOT_ENOUGH_INPUT_DATA;
+        } else {
+          locatorExitCode = LocStatus.NOT_ENOUGH_USEABLE_DATA;
+        }
         break;
 
       default:

--- a/src/main/java/gov/usgs/locator/LocMain.java
+++ b/src/main/java/gov/usgs/locator/LocMain.java
@@ -31,7 +31,7 @@ import org.json.simple.parser.ParseException;
  */
 public class LocMain {
   /** A String containing the locator version */
-  public static final String VERSION = "v0.3.1";
+  public static final String VERSION = "v0.3.2";
 
   /** A String containing the argument for specifying the model file path. */
   public static final String MODELPATH_ARGUMENT = "--modelPath=";

--- a/src/main/java/gov/usgs/locator/LocOutput.java
+++ b/src/main/java/gov/usgs/locator/LocOutput.java
@@ -180,8 +180,10 @@ public class LocOutput extends LocationResult {
       this.LocatorExitCode = "DidNotMove";
     } else if (locatorExitCode == LocStatus.ERRORS_NOT_COMPUTED) {
       this.LocatorExitCode = "ErrorsNotComputed";
-    } else if (locatorExitCode == LocStatus.NOT_ENOUGH_DATA) {
-      this.LocatorExitCode = "NotEnoughData";
+    } else if (locatorExitCode == LocStatus.NOT_ENOUGH_INPUT_DATA) {
+      this.LocatorExitCode = "NotEnoughInputData";
+    } else if (locatorExitCode == LocStatus.NOT_ENOUGH_USEABLE_DATA) {
+      this.LocatorExitCode = "NotEnoughUseableData";
     } else if (locatorExitCode == LocStatus.DID_NOT_CONVERGE) {
       this.LocatorExitCode = "DidNotConverge";
     } else if (locatorExitCode == LocStatus.BAD_EVENT_INPUT) {

--- a/src/main/java/gov/usgs/locator/LocStatus.java
+++ b/src/main/java/gov/usgs/locator/LocStatus.java
@@ -112,8 +112,14 @@ public enum LocStatus {
    */
   LOCATION_FAILED(101), // Location failed (singular or insufficient data)
 
-  /** External (exit) status meaning that there wasn't enough data to locate the event. */
-  NOT_ENOUGH_DATA(104), // Insufficient data
+  /** External (exit) status meaning that there wasn't enough input data to locate the event. */
+  NOT_ENOUGH_INPUT_DATA(103), // Insufficient input data
+
+  /**
+   * External (exit) status meaning that there wasn't enough usable (non-zero-weight) data to locate
+   * the event.
+   */
+  NOT_ENOUGH_USEABLE_DATA(104), // Insufficient data
 
   /** Internal status for a location that can't be improved, but has clearly not converged. */
   DID_NOT_CONVERGE(105), // Unable to improve, but not close to converging

--- a/src/main/java/gov/usgs/locaux/LocUtil.java
+++ b/src/main/java/gov/usgs/locaux/LocUtil.java
@@ -152,30 +152,31 @@ public class LocUtil {
   public static final double DEG2KM = 6371d * Math.PI / 180d;
 
   /** An int constant representing the maximum number of iteration stages to attempt. */
-  public static final int STAGELIMIT = 2;
+  /** JMP 1/13/2022 Added a third stage due to large number of events that did not converge */
+  public static final int STAGELIMIT = 3;
 
   /** A double constant representing the initial step length to start each iteration loop with. */
   public static final double INITIALSTEPLEN = 50d;
 
   /** An array of int constants representing the maximum number of iterations for each stage. */
-  // public static final int[] ITERATIONSTAGELIMITS = {15, 20, 20, 20, 20, 20, 20, 20, 20, 20};
+  /** JMP 1/13/2022 Added a third stage due to large number of events that did not converge */
   public static final int[] ITERATIONSTAGELIMITS = {
-    15, 20
-  }; // Collapse to with and without decorrelation sub-loops 9/16/19.
+    15, 20, 30
+  };
 
   /**
    * An array of double constants representing the convergence criteria in kilometers for each
    * stage.
    */
-  // public static final double[] CONVERGENCESTAGELIMITS = {1d, 0.1d, 0.1d, 0.1d, 0.1d, 0.1d, 0.1d,
-  // 		0.1d, 0.1d, 0.1d};
-  public static final double[] CONVERGENCESTAGELIMITS = {1d, 0.1d};
+  /** JMP 1/13/2022 Added a third stage due to large number of events that did not converge */
+  public static final double[] CONVERGENCESTAGELIMITS = {1d, 0.1d, 0.1d};
 
   /**
    * An array of double constants representing the maximum step length in kilometers to allow for
    * each stage.
    */
-  public static final double[] STEPLENSTAGELIMITS = {200d, 50d};
+  /** JMP 1/13/2022 Added a third stage due to large number of events that did not converge */
+  public static final double[] STEPLENSTAGELIMITS = {200d, 50d, 25d};
 
   /**
    * A double constant representing the step tolerance dividing "did not converge" from "unstable

--- a/src/main/java/gov/usgs/locaux/LocUtil.java
+++ b/src/main/java/gov/usgs/locaux/LocUtil.java
@@ -160,9 +160,7 @@ public class LocUtil {
 
   /** An array of int constants representing the maximum number of iterations for each stage. */
   /** JMP 1/13/2022 Added a third stage due to large number of events that did not converge */
-  public static final int[] ITERATIONSTAGELIMITS = {
-    15, 20, 30
-  };
+  public static final int[] ITERATIONSTAGELIMITS = {15, 20, 30};
 
   /**
    * An array of double constants representing the convergence criteria in kilometers for each

--- a/src/main/java/gov/usgs/locaux/SlabArea.java
+++ b/src/main/java/gov/usgs/locaux/SlabArea.java
@@ -214,7 +214,7 @@ public class SlabArea implements Serializable {
       } else {
         LOGGER.fine(
             String.format(
-                "v0[%d]: (%7.3f, %7.3f, %7.4f\n", j, v0[j][1][0], v0[j][1][1], v0[j][1][2]));
+                "v0[%d]: (%7.3f, %7.3f, %7.4f", j, v0[j][1][0], v0[j][1][1], v0[j][1][2]));
       }
     }
 
@@ -226,13 +226,13 @@ public class SlabArea implements Serializable {
         } else {
           LOGGER.fine(
               String.format(
-                  "v1[%d]: (%7.3f, %7.3f, %7.4f\n", j, v1[j][1][0], v1[j][1][1], v1[j][1][2]));
+                  "v1[%d]: (%7.3f, %7.3f, %7.4f", j, v1[j][1][0], v1[j][1][1], v1[j][1][2]));
         }
       }
     } else {
       nulls += 2;
     }
-    LOGGER.fine(String.format("    v: (%7.3f, %7.3f, %7.4f\n", v[0], v[1], v[2]));
+    LOGGER.fine(String.format("    v: (%7.3f, %7.3f, %7.4f", v[0], v[1], v[2]));
 
     switch (nulls) {
       case 0:
@@ -343,7 +343,7 @@ public class SlabArea implements Serializable {
         lastLat += slabInc;
         slabRows.add(j, new SlabRow(lastLat));
 
-        LOGGER.fine(String.format("Dummy row added: lat = %6.2f\n", lastLat));
+        LOGGER.fine(String.format("Dummy row added: lat = %6.2f", lastLat));
       }
 
       lastLat = slabRows.get(j).getLat();
@@ -359,12 +359,12 @@ public class SlabArea implements Serializable {
       lat += slabInc;
 
       while (Math.abs(slabRows.get(j).getLat() - lat) > TauUtil.DTOL) {
-        LOGGER.fine(String.format("Missing row (lat = %6.2f)\n", lat));
+        LOGGER.fine(String.format("Missing row (lat = %6.2f)", lat));
         lat += slabInc;
       }
 
       if (slabRows.get(j).isDummyRow()) {
-        LOGGER.fine(String.format("Dummy row (lat = %6.2f)\n", lat));
+        LOGGER.fine(String.format("Dummy row (lat = %6.2f)", lat));
       }
     }
   }


### PR DESCRIPTION
This PR includes:
- Integrating the latest version of the travel time library that has the crash fix
- Splitting the insufficient data return into insufficient input data (less than 3 input phases) and insufficient useable data (less than 3 non-zero weight phases)
- Added a third iteration stage due to the large number of "did not converge" events produced by the previous version.