### PR TITLE
Phase-ID changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
 
 sourceCompatibility = "1.10"
 targetCompatibility = "1.10"
-version = "0.3.2"
+version = "0.3.3"
 
 repositories {
     mavenCentral()

--- a/src/main/java/gov/usgs/locator/Event.java
+++ b/src/main/java/gov/usgs/locator/Event.java
@@ -570,13 +570,20 @@ public class Event {
       // make sure phCode and obsCode are not null
       String phCode = "";
       String pickedCode = "";
+      String obsCode = "";
+      String locCode = "";
+
       if (pickIn.PickedPhase != null) {
         phCode = pickIn.PickedPhase;
         pickedCode = pickIn.PickedPhase;
       }
-      String obsCode = "";
+
       if (pickIn.AssociatedPhase != null) {
         obsCode = pickIn.AssociatedPhase;
+      }
+
+      if (pickIn.LocatedPhase != null) {
+        locCode = pickIn.LocatedPhase;
       }
 
       // source type conversion
@@ -618,6 +625,7 @@ public class Event {
           pickIn.Quality,
           obsCode,
           pickedCode,
+          locCode,
           LocUtil.getAuthCodeFromNumericCode(authorType),
           pickIn.Affinity);
       pickList.add(pick);
@@ -1117,11 +1125,11 @@ public class Event {
         break;
 
       case INSUFFICIENT_DATA:
-        // insufficent data can either mean not enough
+        // insufficient data can either mean not enough
         // input data was provided OR there was not
         // enough data with a non-zero weight after
         // phase (re)identification
-        if (numPhasesAssociated < 3) {
+        if (numStationsAssociated < 3) {
           locatorExitCode = LocStatus.NOT_ENOUGH_INPUT_DATA;
         } else {
           locatorExitCode = LocStatus.NOT_ENOUGH_USEABLE_DATA;

--- a/src/main/java/gov/usgs/locator/LocInput.java
+++ b/src/main/java/gov/usgs/locator/LocInput.java
@@ -193,6 +193,7 @@ public class LocInput extends LocationRequest {
       requestPick.Use = pickUse;
       requestPick.PickedPhase = detectPick.getPhase();
       requestPick.AssociatedPhase = detectPick.getAssociationInfo().getPhase();
+      requestPick.LocatedPhase = null;
 
       requestInputData.add(requestPick);
     }
@@ -309,6 +310,7 @@ public class LocInput extends LocationRequest {
       }
       newPick.Affinity = aff;
       newPick.AssociatedPhase = obsPh;
+      newPick.LocatedPhase = null;
 
       if (newPick.isValid()) {
         // Add the pick to the list

--- a/src/main/java/gov/usgs/locator/LocMain.java
+++ b/src/main/java/gov/usgs/locator/LocMain.java
@@ -31,7 +31,7 @@ import org.json.simple.parser.ParseException;
  */
 public class LocMain {
   /** A String containing the locator version */
-  public static final String VERSION = "v0.3.2";
+  public static final String VERSION = "v0.3.3";
 
   /** A String containing the argument for specifying the model file path. */
   public static final String MODELPATH_ARGUMENT = "--modelPath=";

--- a/src/main/java/gov/usgs/locator/Pick.java
+++ b/src/main/java/gov/usgs/locator/Pick.java
@@ -520,8 +520,7 @@ public class Pick implements Comparable<Pick> {
         // for all other known types, we use the locator phase
         // id if we have it, otherwise we use the associator's
         // phase id if we do not
-        if ((originalLocPhaseCode != null) && 
-            (originalLocPhaseCode != "")) {
+        if ((originalLocPhaseCode != null) && (originalLocPhaseCode != "")) {
           currentPhaseCode = originalLocPhaseCode;
           bestPhaseCode = originalLocPhaseCode;
         } else {
@@ -533,7 +532,7 @@ public class Pick implements Comparable<Pick> {
 
       default:
         // if we do no have an author type, we default
-        // to what the current phase code was set to 
+        // to what the current phase code was set to
         // in the constructor, which is currently set the
         // by Event.java to be the picker's phase id.
         bestPhaseCode = currentPhaseCode;

--- a/src/main/java/gov/usgs/locator/Pick.java
+++ b/src/main/java/gov/usgs/locator/Pick.java
@@ -508,6 +508,7 @@ public class Pick implements Comparable<Pick> {
     switch (originalAuthorType) {
       case LOCAL_HUMAN:
         // for a local human we always trust their phase id
+        // we ignore the previous locator phase id
         currentPhaseCode = originalAssocPhaseCode;
         bestPhaseCode = originalAssocPhaseCode;
         isAutomatic = false;
@@ -516,9 +517,9 @@ public class Pick implements Comparable<Pick> {
       case CONTRIB_HUMAN:
       case CONTRIB_AUTO:
       case LOCAL_AUTO:
-        // for all other know types, we use the locator phase
-        // id if we have it, otherwise use the associator's
-        // phase id
+        // for all other known types, we use the locator phase
+        // id if we have it, otherwise we use the associator's
+        // phase id if we do not
         if ((originalLocPhaseCode != null) && 
             (originalLocPhaseCode != "")) {
           currentPhaseCode = originalLocPhaseCode;
@@ -532,8 +533,9 @@ public class Pick implements Comparable<Pick> {
 
       default:
         // if we do no have an author type, we default
-        // to what was set in the constructor, which is the
-        // picker's phase id.
+        // to what the current phase code was set to 
+        // in the constructor, which is currently set the
+        // by Event.java to be the picker's phase id.
         bestPhaseCode = currentPhaseCode;
         break;
     }

--- a/src/main/java/gov/usgs/locator/Pick.java
+++ b/src/main/java/gov/usgs/locator/Pick.java
@@ -39,6 +39,9 @@ public class Pick implements Comparable<Pick> {
   /** A String containing the original picked phase identification for this pick. */
   private String originalPickedPhaseCode;
 
+  /** A String containing the original located phase identification for this pick. */
+  private String originalLocPhaseCode;
+
   /** An AuthorType object containing the author type for the original phase identification. */
   private AuthorType originalAuthorType;
 
@@ -184,6 +187,15 @@ public class Pick implements Comparable<Pick> {
    */
   public String getOriginalPickedPhaseCode() {
     return originalPickedPhaseCode;
+  }
+
+  /**
+   * Function to return the original loc phase code for the pick.
+   *
+   * @return A String containing the original loc pick phase code for the pick
+   */
+  public String getOriginalLocPhaseCode() {
+    return originalLocPhaseCode;
   }
 
   /**
@@ -437,6 +449,7 @@ public class Pick implements Comparable<Pick> {
     quality = 0d;
     originalAssocPhaseCode = null;
     originalPickedPhaseCode = null;
+    originalLocPhaseCode = null;
     originalAuthorType = null;
     originalPhaseAffinity = 3d;
     isUsed = externalUse;
@@ -467,6 +480,8 @@ public class Pick implements Comparable<Pick> {
    *     identification
    * @param originalPickedPhaseCode A String containing the original picker external pick phase
    *     identification
+   * @param originalLocPhaseCode A String containing the original locator external pick phase
+   *     identification
    * @param originalAuthorType An AuthorType object containing the type (e.g., human or auto) of the
    *     original phase identification
    * @param originalPhaseAffinity Higher numbers make it harder to re-identify the phase
@@ -477,6 +492,7 @@ public class Pick implements Comparable<Pick> {
       double quality,
       String originalAssocPhaseCode,
       String originalPickedPhaseCode,
+      String originalLocPhaseCode,
       AuthorType originalAuthorType,
       double originalPhaseAffinity) {
     this.sourceID = sourceID;
@@ -484,19 +500,40 @@ public class Pick implements Comparable<Pick> {
     this.quality = quality;
     this.originalAssocPhaseCode = originalAssocPhaseCode;
     this.originalPickedPhaseCode = originalPickedPhaseCode;
+    this.originalLocPhaseCode = originalLocPhaseCode;
     this.originalAuthorType = originalAuthorType;
     this.originalPhaseAffinity = originalAuthorType.affinity(originalPhaseAffinity);
 
     // Use the enum for the author type.
     switch (originalAuthorType) {
-      case CONTRIB_HUMAN:
       case LOCAL_HUMAN:
+        // for a local human we always trust their phase id
         currentPhaseCode = originalAssocPhaseCode;
         bestPhaseCode = originalAssocPhaseCode;
         isAutomatic = false;
         break;
 
+      case CONTRIB_HUMAN:
+      case CONTRIB_AUTO:
+      case LOCAL_AUTO:
+        // for all other know types, we use the locator phase
+        // id if we have it, otherwise use the associator's
+        // phase id
+        if ((originalLocPhaseCode != null) && 
+            (originalLocPhaseCode != "")) {
+          currentPhaseCode = originalLocPhaseCode;
+          bestPhaseCode = originalLocPhaseCode;
+        } else {
+          currentPhaseCode = originalAssocPhaseCode;
+          bestPhaseCode = originalAssocPhaseCode;
+        }
+        isAutomatic = true;
+        break;
+
       default:
+        // if we do no have an author type, we default
+        // to what was set in the constructor, which is the
+        // picker's phase id.
         bestPhaseCode = currentPhaseCode;
         break;
     }

--- a/src/main/java/gov/usgs/locaux/LocUtil.java
+++ b/src/main/java/gov/usgs/locaux/LocUtil.java
@@ -923,10 +923,15 @@ public class LocUtil {
    * @return An AuthorType object containing the author type
    */
   public static AuthorType getAuthCodeFromNumericCode(int authCode) {
-    for (AuthorType author : AuthorType.values()) {
-      if (author.ordinal() == authCode) {
-        return author;
-      }
+
+    if (authCode == 1) {
+      return AuthorType.CONTRIB_AUTO;
+    } else if (authCode == 2) {
+      return AuthorType.LOCAL_AUTO;
+    } else if (authCode == 3) {
+      return AuthorType.CONTRIB_HUMAN;
+    } else if (authCode == 4) {
+      return AuthorType.LOCAL_HUMAN;
     }
 
     return AuthorType.UNKNOWN;

--- a/src/test/resources/bigVerification.json
+++ b/src/test/resources/bigVerification.json
@@ -1,5 +1,5 @@
 {
-    "MinimumDistance": 7.189015220157172,
+    "MinimumDistance": 7.187240562499663,
     "SupportingData": [
       {
         "Site": {
@@ -8059,21 +8059,21 @@
       }
     },
     "Hypocenter": {
-      "LatitudeError": 10.334174805604148,
-      "DepthError": 4.516944393998877,
-      "TimeError": 2.314332340503762,
-      "Latitude": -57.55078244049887,
-      "Time": "2021-08-12T18:32:52.335Z",
-      "Longitude": -25.09595398388939,
-      "Depth": 46.72968374757601,
-      "LongitudeError": 9.643337993168855
+      "LatitudeError": 10.376554327626398,
+      "DepthError": 4.518032092211938,
+      "TimeError": 2.2994878674967216,
+      "Latitude": -57.54896641843,
+      "Time": "2021-08-12T18:32:52.328Z",
+      "Longitude": -25.098128296641534,
+      "Depth": 46.64339779219844,
+      "LongitudeError": 9.699393175259418
     },
     "DepthImportance": 0.09878431787875633,
     "Quality": "B* ",
-    "Gap": 37.68506566294704,
+    "Gap": 37.683273016452716,
     "BayesianDepth": 45.595611572265625,
     "SecondaryGap": 50.922150088761995,
-    "RMS": 1.140899172801124,
+    "RMS": 1.1335812752468277,
     "NumberOfAssociatedStations": 267,
     "NumberOfAssociatedPhases": 277,
     "NumberOfUsedPhases": 87

--- a/src/test/resources/deepVerification.json
+++ b/src/test/resources/deepVerification.json
@@ -1,5 +1,5 @@
 {
-    "MinimumDistance": 3.863007352662042,
+    "MinimumDistance": 3.8624787874519857,
     "SupportingData": [
       {
         "Site": {
@@ -21805,21 +21805,21 @@
       }
     },
     "Hypocenter": {
-      "LatitudeError": 10.595983779626739,
-      "DepthError": 4.92918053158718,
-      "TimeError": 1.8955089533554794,
-      "Latitude": -18.333113850000938,
-      "Time": "2021-08-12T03:46:59.944Z",
-      "Longitude": -177.93384421002952,
-      "Depth": 521.597272143306,
-      "LongitudeError": 3.2194893335621027
+      "LatitudeError": 10.646203680576361,
+      "DepthError": 5.06937069210554,
+      "TimeError": 1.7959263685585591,
+      "Latitude": -18.316904737005565,
+      "Time": "2021-08-12T03:47:00.016Z",
+      "Longitude": -177.93202985010925,
+      "Depth": 522.2071717582241,
+      "LongitudeError": 10.666952859603443
     },
     "DepthImportance": 0.07854751620219186,
-    "Quality": "A  ",
-    "Gap": 35.4686789998633,
+    "Quality": "B* ",
+    "Gap": 35.499548331937135,
     "BayesianDepth": 521.06494140625,
     "SecondaryGap": 45.06855395695441,
-    "RMS": 0.9344313083615552,
+    "RMS": 0.8853399628223602,
     "NumberOfAssociatedStations": 743,
     "NumberOfAssociatedPhases": 751,
     "NumberOfUsedPhases": 110

--- a/src/test/resources/localVerification.json
+++ b/src/test/resources/localVerification.json
@@ -1,5 +1,5 @@
 {
-    "MinimumDistance": 0.08648309493230734,
+    "MinimumDistance": 0.08907566041743417,
     "SupportingData": [
       {
         "Site": {
@@ -2809,21 +2809,21 @@
       }
     },
     "Hypocenter": {
-      "LatitudeError": 0.953428816690617,
-      "DepthError": 1.8240190910751766,
-      "TimeError": 1.033901565949068,
-      "Latitude": 31.02636752545245,
-      "Time": "2021-08-12T02:25:02.363Z",
-      "Longitude": -103.32577470183911,
+      "LatitudeError": 0.9635926184652294,
+      "DepthError": 1.8173941118860482,
+      "TimeError": 1.0046416764486283,
+      "Latitude": 31.0329100324501,
+      "Time": "2021-08-12T02:25:02.474Z",
+      "Longitude": -103.30855941920419,
       "Depth": 10,
-      "LongitudeError": 1.1674098848974965
+      "LongitudeError": 1.2024393416996788
     },
     "DepthImportance": 0.6113207885426758,
     "Quality": "G G",
-    "Gap": 55.620515046859424,
+    "Gap": 54.263832293677154,
     "BayesianDepth": 10,
     "SecondaryGap": 78.71517645597197,
-    "RMS": 0.5096836874743405,
+    "RMS": 0.49525940486675374,
     "NumberOfAssociatedStations": 73,
     "NumberOfAssociatedPhases": 96,
     "NumberOfUsedPhases": 35


### PR DESCRIPTION
Modifies the initial setup of phase names from the input to prefer associator phase codes from local humans, and locator phase codes if present for all other author types.

Updates regression test validation values for current version.

Bumped version